### PR TITLE
Root Brick

### DIFF
--- a/bricks/aem-root/aem-root.html
+++ b/bricks/aem-root/aem-root.html
@@ -35,16 +35,12 @@
   </style>
 
   <body>
-    <header>
-      <!-- <aem-header></aem-header> -->
-    </header>
+    <aem-header></aem-header>
 
     <main>
       <slot name="main"></slot>
     </main>
 
-    <footer>
-      <!-- <aem-footer></aem-footer> -->
-    </footer>
+    <aem-footer></aem-footer>
   </body>
 </template>

--- a/bricks/aem-root/aem-root.html
+++ b/bricks/aem-root/aem-root.html
@@ -1,0 +1,50 @@
+<template>
+  <style>
+    :host {
+      font-size: var(--body-font-size-m);
+      font-family: var(--body-font-family);
+      line-height: 1.6;
+      color: var(--text-color);
+      background-color: var(--background-color);
+    }
+
+    header {
+      height: var(--nav-height);
+    }
+
+    .section {
+      padding: 64px 16px;
+    }
+
+    .wrapper {
+      max-width: 1200px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    @media (width >= 600px) {
+      .section {
+        padding: 64px 32px;
+      }
+    }
+
+    /* section metadata */
+    .section.highlight {
+      background-color: var(--highlight-background-color);
+    }
+  </style>
+
+  <body>
+    <header>
+      <!-- <aem-header></aem-header> -->
+    </header>
+
+    <main>
+      <slot name="main"></slot>
+    </main>
+
+    <footer>
+      <!-- <aem-footer></aem-footer> -->
+    </footer>
+  </body>
+</template>

--- a/bricks/aem-root/aem-root.js
+++ b/bricks/aem-root/aem-root.js
@@ -1,0 +1,28 @@
+import { Brick } from '../../scripts/aem.js';
+
+export default class Footer extends Brick {
+  async connectedCallback() {
+    // Main Sections
+    const main = this.shadowRoot.querySelector('slot[name="main"]');
+    main.innerHTML = this.root.querySelector('main').innerHTML;
+
+    // Decorate Sections
+    [...main.children].forEach((section) => {
+      // Purge empty DIVs
+      if (section.children.length === 0) {
+        section.remove();
+        return;
+      }
+
+      // Sections
+      if (section.tagName === 'DIV') {
+        section.classList.add('wrapper');
+
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('section');
+        section.parentNode.insertBefore(wrapper, section);
+        wrapper.appendChild(section);
+      }
+    });
+  }
+}

--- a/bricks/aem-section-metadata/aem-section-metadata.js
+++ b/bricks/aem-section-metadata/aem-section-metadata.js
@@ -8,9 +8,9 @@ export default class SectionMetadata extends Brick {
   connectedCallback() {
     [...this.values].forEach(([key, value]) => {
       if (key.toLowerCase() === 'style') {
-        this.parentElement.classList.add(value);
+        this.parentElement.parentElement.classList.add(value);
       } else {
-        this.parentElement.dataset[key] = value;
+        this.parentElement.parentElement.dataset[key] = value;
       }
     });
   }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -439,13 +439,8 @@ export default async function initialize() {
   // Decorate Root
   decorateRoot();
 
-  // Load common brick styles
-  if (css.value) {
-    window.hlx.blockStyles = css.value;
-    const sheet = new CSSStyleSheet();
-    sheet.replaceSync(css.value);
-    document.adoptedStyleSheets = [sheet];
-  }
+  // common brick styles
+  window.hlx.blockStyles = css.value;
 
   // Define custom elements
   loadedComponents.value.forEach(async ({ status, value }) => {

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -174,6 +174,17 @@ function buildHeroBrick() {
 }
 
 /**
+ * Decorate root.
+ */
+function decorateRoot() {
+  const root = document.createElement('aem-root');
+  root.append(document.querySelector('header'));
+  root.append(document.querySelector('main'));
+  root.append(document.querySelector('footer'));
+  document.body.prepend(root);
+}
+
+/**
  * log RUM if part of the sample.
  * @param {string} checkpoint identifies the checkpoint in funnel
  * @param {Object} data additional data for RUM sample
@@ -335,11 +346,12 @@ function transformToCustomElement(brick) {
 }
 
 function getBrickResources() {
-  const components = new Set();
-  const templates = new Set();
+  const components = new Set(['aem-root']);
+  const templates = new Set(['aem-root']);
 
-  document
-    .querySelectorAll('header, footer, div[class]:not(.fragment):not(.section)')
+  // Load Bricks
+  document.body
+    .querySelectorAll('div[class]:not(.fragment)')
     .forEach((brick) => {
       const { status } = brick.dataset;
 
@@ -424,6 +436,9 @@ export default async function initialize() {
     Promise.allSettled([...templates].map(loadTemplate)),
   ]);
 
+  // Decorate Root
+  decorateRoot();
+
   // Load common brick styles
   if (css.value) {
     window.hlx.blockStyles = css.value;
@@ -440,11 +455,6 @@ export default async function initialize() {
         customElements.define(value.name, value.className);
       }
     }
-  });
-
-  // Add sections class to all parent divs
-  document.querySelectorAll('main > div').forEach((section) => {
-    section.classList.add('section');
   });
 
   // Page is fully loaded
@@ -515,9 +525,9 @@ export class Brick extends HTMLElement {
     // Set up MutationObserver to detect changes in child nodes
     this.observer = new MutationObserver((event) => {
       event.forEach((mutation) => {
-        mutation.addedNodes.forEach((node) => {
-          node.querySelectorAll('.icon').forEach(decorateIcon);
-          node.querySelectorAll('a').forEach(decorateButton);
+        mutation.addedNodes?.forEach((node) => {
+          node.querySelectorAll?.('.icon').forEach(decorateIcon);
+          node.querySelectorAll?.('a').forEach(decorateButton);
         });
       });
     });

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -103,6 +103,8 @@ async function loadFonts() {
  * @param {span} [element] span element with icon classes
  */
 function decorateIcon(elem) {
+  if (elem.dataset.decorated) return;
+
   const iconName = Array.from(elem.classList)
     .find((c) => c.startsWith('icon-'))
     .substring(5);
@@ -111,6 +113,7 @@ function decorateIcon(elem) {
   img.src = `${window.hlx.codeBasePath}/icons/${iconName}.svg`;
   img.loading = 'lazy';
   elem.append(img);
+  elem.dataset.decorated = true;
 }
 
 /**
@@ -118,6 +121,8 @@ function decorateIcon(elem) {
  * @param {Element} element container element
  */
 function decorateButton(a) {
+  if (a.dataset.decorated) return;
+
   a.title = a.title || a.textContent;
 
   if (a.href !== a.textContent) {
@@ -143,6 +148,8 @@ function decorateButton(a) {
     ) {
       a.className = 'button secondary';
     }
+
+    a.dataset.decorated = true;
   }
 }
 
@@ -521,8 +528,8 @@ export class Brick extends HTMLElement {
     this.observer = new MutationObserver((event) => {
       event.forEach((mutation) => {
         mutation.addedNodes?.forEach((node) => {
-          node.querySelectorAll?.('.icon').forEach(decorateIcon);
-          node.querySelectorAll?.('a').forEach(decorateButton);
+          node.querySelectorAll?.('.icon:not([data-decorated])').forEach(decorateIcon);
+          node.querySelectorAll?.('a:not([data-decorated])').forEach(decorateButton);
         });
       });
     });

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -346,8 +346,8 @@ function transformToCustomElement(brick) {
 }
 
 function getBrickResources() {
-  const components = new Set(['aem-root']);
-  const templates = new Set(['aem-root']);
+  const components = new Set(['aem-root', 'aem-header', 'aem-footer']);
+  const templates = new Set(['aem-root', 'aem-header', 'aem-footer']);
 
   // Load Bricks
   document.body

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -504,12 +504,12 @@ export class Brick extends HTMLElement {
 
     const slots = this.querySelectorAll('[slot="item"]');
 
-    slots.forEach((element) => {
-      if (options.mapValues) {
+    if (options.mapValues) {
+      slots.forEach((element) => {
         const [key, value] = element.children;
         this.values.set(key.innerText, value.innerHTML);
-      }
-    });
+      });
+    }
 
     // clone root
     const root = document.createElement('div');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -61,40 +61,9 @@
 }
 
 body {
-  font-size: var(--body-font-size-m);
   margin: 0;
-  font-family: var(--body-font-family);
-  line-height: 1.6;
-  color: var(--text-color);
-  background-color: var(--background-color);
 }
 
-/* Use opacity over display: none to let the browser download LCP image assets */
 body:not([data-status='loaded']) {
   display: none;
-}
-
-header {
-  height: var(--nav-height);
-}
-
-.section {
-  padding: 64px 16px;
-}
-
-.section > * {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-@media (width >= 600px) {
-  .section {
-    padding: 64px 32px;
-  }
-}
-
-/* section metadata */
-.section.highlight {
-  background-color: var(--highlight-background-color);
 }


### PR DESCRIPTION
This PR introduces the `<aem-root>` brick that can be use to create a template for the `body` and decorate as needed from the project level.

The root brick is responsible for the template, style, and javascript of the body tag that includes (or may not include) `header`, `main`, and `footer`

Look at https://github.com/adobe-gw2023-project-bricks/aem-wc-boilerplate/tree/mainbrick/bricks/aem-root for an example.

Fix #31 

Test URLs:
- Before: https://main--aem-wc-boilerplate--adobe-gw2023-project-bricks.hlx.page/
- After: https://mainbrick--aem-wc-boilerplate--adobe-gw2023-project-bricks.hlx.page/
